### PR TITLE
feat: add GitHub multi-agent collaboration control plane

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-work-item.yml
+++ b/.github/ISSUE_TEMPLATE/agent-work-item.yml
@@ -1,0 +1,63 @@
+name: Agent Work Item
+description: Standard task template for multi-agent execution.
+title: "[Work] "
+labels:
+  - status:triage
+  - lane:core
+  - priority:p2
+  - risk:low
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem or opportunity are we addressing?
+      placeholder: Describe the context and desired outcome.
+    validations:
+      required: true
+  - type: dropdown
+    id: work_type
+    attributes:
+      label: Work Type
+      options:
+        - Feature
+        - Bug Fix
+        - Reliability
+        - Governance/Workflow
+        - Documentation
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is explicitly in scope and out of scope?
+      placeholder: In scope..., Out of scope...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: List deterministic checks that define done.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and Dependencies
+      description: Note regressions, blockers, or linked dependencies.
+      placeholder: blocked-by #123, risk areas...
+    validations:
+      required: false
+  - type: input
+    id: owner
+    attributes:
+      label: Suggested Owner
+      description: Agent or human expected to execute this item.
+      placeholder: agent:codex
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Architecture / RFC Discussion
+    url: https://github.com/ingpoc/nanoclaw/discussions
+    about: Use Discussions for design debates and non-immediate execution topics.

--- a/.github/ISSUE_TEMPLATE/incident-report.yml
+++ b/.github/ISSUE_TEMPLATE/incident-report.yml
@@ -1,0 +1,50 @@
+name: Incident Report
+description: Runtime or reliability incident requiring triage and RCA.
+title: "[Incident] "
+labels:
+  - status:triage
+  - lane:runtime
+  - priority:p1
+  - risk:high
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Incident Summary
+      description: What failed, where, and user impact?
+      placeholder: Brief incident description.
+    validations:
+      required: true
+  - type: input
+    id: observed_at
+    attributes:
+      label: Observed Time (UTC)
+      placeholder: "2026-03-06T12:00:00Z"
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, run IDs, traces, or diagnostics bundle locations.
+      placeholder: run_id=..., incident bundle path=...
+    validations:
+      required: true
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Immediate Mitigation
+      description: What was done to stabilize?
+      placeholder: Recovery steps performed.
+    validations:
+      required: false
+  - type: textarea
+    id: followup
+    attributes:
+      label: Follow-up Actions
+      description: Deterministic prevention items and owners.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,32 @@
+## Linked Work Item
+
+- Fixes #<issue-id>
+
 ## Type of Change
 
-- [ ] **Skill** - adds a new skill in `.claude/skills/`
+- [ ] **Skill** - adds or updates skill content in `.claude/skills/`
+- [ ] **Feature** - new product behavior
 - [ ] **Fix** - bug fix or security fix to source code
-- [ ] **Simplification** - reduces or simplifies source code
+- [ ] **Reliability** - runtime or operational hardening
+- [ ] **Governance/Workflow** - CI/policy/process automation changes
+- [ ] **Docs** - documentation-only change
 
-## Description
+## Summary
 
+Describe the intent, scope boundary, and expected outcome.
 
-## For Skills
+## Verification Evidence
 
-- [ ] I have not made any changes to source code
-- [ ] My skill contains instructions for Claude to follow (not pre-built code)
-- [ ] I tested this skill on a fresh clone
+- [ ] Build/type/test checks executed (or intentionally not required)
+- [ ] Risk-prone paths were validated
+- [ ] Relevant acceptance criteria from linked issue are satisfied
+
+## Risks and Rollback
+
+List known risks and rollback path.
+
+## Skill-Specific Checks (Only if skill change)
+
+- [ ] I have not made source code changes in this PR when introducing a new skill
+- [ ] Skill content is instruction-oriented (not pre-baked implementation)
+- [ ] Skill validation path was exercised

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "lane:core",
+    "color": "1D76DB",
+    "description": "Core product implementation lane."
+  },
+  {
+    "name": "lane:runtime",
+    "color": "BFD4F2",
+    "description": "Runtime, reliability, and infrastructure lane."
+  },
+  {
+    "name": "lane:control-plane",
+    "color": "5319E7",
+    "description": "GitHub workflow, policy, and governance lane."
+  },
+  {
+    "name": "lane:docs",
+    "color": "0E8A16",
+    "description": "Documentation and operating agreement lane."
+  },
+  {
+    "name": "priority:p0",
+    "color": "B60205",
+    "description": "Urgent work requiring immediate attention."
+  },
+  {
+    "name": "priority:p1",
+    "color": "D93F0B",
+    "description": "High-priority work for the current cycle."
+  },
+  {
+    "name": "priority:p2",
+    "color": "FBCA04",
+    "description": "Normal-priority backlog item."
+  },
+  {
+    "name": "risk:high",
+    "color": "B60205",
+    "description": "High risk of regression, security, or runtime impact."
+  },
+  {
+    "name": "risk:medium",
+    "color": "D93F0B",
+    "description": "Moderate risk requiring explicit verification."
+  },
+  {
+    "name": "risk:low",
+    "color": "0E8A16",
+    "description": "Low-risk and routine changes."
+  },
+  {
+    "name": "agent:claude",
+    "color": "C2E0C6",
+    "description": "Owned by Claude lane."
+  },
+  {
+    "name": "agent:codex",
+    "color": "BFDADC",
+    "description": "Owned by Codex lane."
+  },
+  {
+    "name": "agent:human",
+    "color": "F9D0C4",
+    "description": "Owned by a human operator."
+  },
+  {
+    "name": "status:blocked",
+    "color": "E4E669",
+    "description": "Blocked by dependency or external input."
+  },
+  {
+    "name": "status:triage",
+    "color": "C5DEF5",
+    "description": "Needs initial triage and assignment."
+  }
+]

--- a/.github/workflows/multi-agent-governance.yml
+++ b/.github/workflows/multi-agent-governance.yml
@@ -1,0 +1,78 @@
+name: Multi-Agent Governance
+
+on:
+  issues:
+    types: [opened, edited, reopened, unlabeled]
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  issue-default-labels:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Ensure required issue labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const existing = new Set((issue.labels || []).map((l) => l.name));
+            const requiredGroups = [
+              { prefix: "lane:", fallback: "lane:core" },
+              { prefix: "priority:", fallback: "priority:p2" },
+              { prefix: "risk:", fallback: "risk:low" },
+            ];
+
+            const add = [];
+            for (const group of requiredGroups) {
+              const hasGroup = Array.from(existing).some((name) => name.startsWith(group.prefix));
+              if (!hasGroup) add.push(group.fallback);
+            }
+
+            if (context.payload.action === "opened" && !existing.has("status:triage")) {
+              add.push("status:triage");
+            }
+
+            if (add.length === 0) {
+              core.info("Issue already has required label groups.");
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: add,
+            });
+            core.info(`Added labels: ${add.join(", ")}`);
+
+  pr-linked-issue:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Enforce issue linkage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const closesKeyword = /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+\b/i;
+            const genericIssueRef = /\B#\d+\b/;
+
+            if (closesKeyword.test(body) || genericIssueRef.test(body)) {
+              core.info("Issue link detected in PR body.");
+              return;
+            }
+
+            core.setFailed(
+              "PR body must include at least one issue reference. Use `Fixes #<issue-id>` in the Linked Work Item section."
+            );

--- a/.github/workflows/project-intake-sync.yml
+++ b/.github/workflows/project-intake-sync.yml
@@ -1,0 +1,22 @@
+name: Project Intake Sync
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    if: secrets.ADD_TO_PROJECT_PAT != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add item to project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/ingpoc/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/docs/workflow/github-multi-agent-collaboration-loop.md
+++ b/docs/workflow/github-multi-agent-collaboration-loop.md
@@ -1,0 +1,182 @@
+# GitHub Multi-Agent Collaboration Loop
+
+Reusable operating workflow for projects where multiple agents contribute to the same codebase.
+
+Use this to eliminate siloed execution by making GitHub the shared planning, ownership, and governance layer.
+
+Mission anchor: `docs/MISSION.md`.
+
+## Objective
+
+Coordinate many agents with high throughput and low operator overhead by:
+
+1. Centralizing work state in GitHub Issues/Projects.
+2. Enforcing deterministic merge and security invariants in GitHub.
+3. Keeping context-heavy runtime/debug tasks in local agent lanes.
+
+## Applicability
+
+Use when any of these are true:
+
+1. More than one agent contributes in parallel.
+2. Work items are frequently blocked by hidden cross-agent dependencies.
+3. PR review quality is inconsistent because ownership is unclear.
+4. Operators spend time manually reconciling status across tools.
+
+## Core Principle
+
+GitHub is the system of record for work coordination.
+Agent memory is transient; Issue/Project state is durable.
+
+## Capability Model
+
+### Coordination Plane
+
+1. Issues + sub-issues + dependencies.
+2. Projects (v2) with required fields and status flow.
+3. Discussions for non-actionable exploration and RFC-style debates.
+
+### Governance Plane
+
+1. Rulesets / branch protection.
+2. Required checks and merge policy.
+3. CODEOWNERS and review ownership.
+4. Security checks (dependency review, code scanning, secret scanning, Dependabot).
+
+### Execution Plane
+
+1. Agents implement from Issue context and link PRs back to Issues.
+2. Auto-correct lanes (metadata drift, generated artifacts) run as bot PRs.
+3. Runtime/stateful recovery and incident loops stay in local lanes.
+
+## Standard Workflow
+
+### Phase 1: Intake
+
+1. Create Issue using an issue form (problem, scope, acceptance, risks).
+2. Add labels: `lane:*`, `priority:*`, `risk:*`, optional `agent:*`.
+3. If large, create sub-issues and link dependencies (`blocked-by`).
+
+### Phase 2: Planning
+
+1. Add each Issue to Project v2.
+2. Set required fields:
+   - `Status`: Backlog/Ready/In Progress/Review/Blocked/Done
+   - `Agent`
+   - `Lane`
+   - `Priority`
+   - `Target`
+3. Keep only one active owner per Issue.
+
+### Phase 3: Execution
+
+1. Agent claims Issue (`Agent` field + assignee + `In Progress`).
+2. Agent opens PR linked to one primary Issue (`Fixes #<id>`).
+3. PR template requires:
+   - linked Issue
+   - scope summary
+   - test evidence
+   - risk notes
+
+### Phase 4: Governance and Merge
+
+1. Rulesets require PR + required checks + conversation resolution.
+2. CODEOWNERS required for critical paths.
+3. Use auto-merge for compliant PRs.
+4. Use merge queue when parallel PR pressure rises.
+
+### Phase 5: Closeout
+
+1. PR merge auto-closes linked Issue.
+2. Project item moves to `Done` automatically.
+3. If follow-up discovered, open new Issue (do not hide in PR comments).
+
+## Auto-Correct-First Policy
+
+Keep operator load low with this split:
+
+### Hard blocking
+
+1. Build/type/test failures.
+2. Policy/ruleset violations.
+3. High-severity security findings.
+4. Missing required review ownership.
+
+### Auto-correct (non-blocking)
+
+1. Version metadata updates.
+2. Token/badge/doc generated artifact drift.
+3. Routine dependency update PRs.
+4. Mechanical template/schema drift.
+
+### Advisory only
+
+1. Performance trend warnings.
+2. Low-severity hygiene findings.
+3. Non-critical optimization recommendations.
+
+## Required Repository Baseline
+
+1. `main` protected by ruleset or branch protection.
+2. Required status checks configured.
+3. Auto-merge enabled.
+4. Squash merge enabled (recommended for linear history).
+5. Issue templates and PR template present.
+6. CODEOWNERS present for critical paths.
+
+## Portability Checklist (For Other Projects)
+
+Copy this workflow by applying:
+
+1. New Project board with standard fields/statuses.
+2. Shared label taxonomy (`lane:*`, `priority:*`, `risk:*`, `agent:*`).
+3. Ruleset baseline with minimal required checks.
+4. Security baseline workflows (dependency review, code scanning, secret scanning, Dependabot).
+5. Reusable workflow modules (`workflow_call`) for common checks.
+6. CLAUDE/AGENTS trigger line to this workflow doc in each target repo.
+
+## Implementation Assets (This Repository)
+
+Use these assets as the standard starter pack for this and future repositories:
+
+1. `.github/ISSUE_TEMPLATE/agent-work-item.yml`
+2. `.github/ISSUE_TEMPLATE/incident-report.yml`
+3. `.github/PULL_REQUEST_TEMPLATE.md` (issue-link contract)
+4. `.github/labels.json` (portable label taxonomy)
+5. `.github/workflows/multi-agent-governance.yml` (auto-label + issue-link enforcement)
+6. `.github/workflows/project-intake-sync.yml` (auto-add Issues/PRs to Project board when PAT is configured)
+7. `scripts/workflow/sync-github-labels.sh` (safe label upsert, non-destructive)
+8. `scripts/workflow/apply-branch-protection-baseline.sh` (low-friction branch protection baseline)
+
+Bootstrap sequence:
+
+```bash
+bash scripts/workflow/sync-github-labels.sh <owner/repo>
+bash scripts/workflow/apply-branch-protection-baseline.sh <owner/repo> [branch]
+```
+
+Project automation prerequisite:
+
+1. Add repository secret `ADD_TO_PROJECT_PAT` with `project` + repository scopes.
+2. Set `project-url` in `.github/workflows/project-intake-sync.yml` to the target board.
+
+## Suggested Metrics
+
+Track weekly:
+
+1. `issue_cycle_time_days` (open -> done).
+2. `blocked_issue_ratio`.
+3. `pr_first_pass_rate` (merged without rework cycles).
+4. `required-check-failure-rate`.
+5. `security-alert-open-count`.
+6. `automation-vs-manual-fix ratio`.
+
+Adopt workflow changes only when reliability holds and operator burden stays flat or improves.
+
+## Anti-Patterns
+
+1. Agents working without Issue IDs.
+2. Multiple active PRs for one Issue without explicit split.
+3. Long-lived “In Progress” items with no status heartbeat.
+4. Treating Discussions as execution tracking.
+5. Adding blocking checks without latency/noise evidence.

--- a/scripts/workflow/apply-branch-protection-baseline.sh
+++ b/scripts/workflow/apply-branch-protection-baseline.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-}"
+BRANCH="${2:-main}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/workflow/apply-branch-protection-baseline.sh <owner/repo> [branch]
+
+Applies a low-friction branch protection baseline:
+  - Pull-request based merges required
+  - Linear history required
+  - Conversation resolution required
+  - No force-pushes or deletions
+  - No mandatory approvals by default
+
+Status checks are intentionally not set by this script. Add them separately once
+stable required-check contexts are confirmed for the repository.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [ -z "$REPO" ]; then
+  usage
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required." >&2
+  exit 1
+fi
+
+echo "Applying branch protection baseline to $REPO:$BRANCH"
+
+gh api --method PUT "repos/$REPO/branches/$BRANCH/protection" --input - <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+JSON
+
+echo "Baseline applied."

--- a/scripts/workflow/sync-github-labels.sh
+++ b/scripts/workflow/sync-github-labels.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+REPO="${1:-}"
+LABELS_FILE="${2:-.github/labels.json}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/workflow/sync-github-labels.sh [repo] [labels-file]
+
+Upserts label taxonomy from a JSON file into a GitHub repository.
+Does not delete existing labels.
+
+Arguments:
+  repo         Target repository in owner/name format (default: current gh repo)
+  labels-file  JSON array with name/color/description fields (default: .github/labels.json)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [ ! -f "$LABELS_FILE" ]; then
+  echo "Labels file not found: $LABELS_FILE" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required." >&2
+  exit 1
+fi
+
+if [ -z "$REPO" ]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+if ! jq -e 'type == "array"' "$LABELS_FILE" >/dev/null; then
+  echo "Expected JSON array in $LABELS_FILE" >&2
+  exit 1
+fi
+
+echo "Syncing labels to $REPO from $LABELS_FILE"
+
+jq -c '.[]' "$LABELS_FILE" | while IFS= read -r row; do
+  name="$(jq -r '.name' <<<"$row")"
+  color="$(jq -r '.color' <<<"$row")"
+  description="$(jq -r '.description // ""' <<<"$row")"
+
+  if [ -z "$name" ] || [ "$name" = "null" ]; then
+    echo "Skipping label with missing name: $row"
+    continue
+  fi
+
+  encoded_name="$(printf '%s' "$name" | jq -sRr @uri)"
+
+  if gh api "repos/$REPO/labels/$encoded_name" >/dev/null 2>&1; then
+    gh api --method PATCH "repos/$REPO/labels/$encoded_name" \
+      -f new_name="$name" \
+      -f color="$color" \
+      -f description="$description" >/dev/null
+    echo "updated: $name"
+  else
+    gh api --method POST "repos/$REPO/labels" \
+      -f name="$name" \
+      -f color="$color" \
+      -f description="$description" >/dev/null
+    echo "created: $name"
+  fi
+done
+
+echo "Label sync complete."


### PR DESCRIPTION
## Summary
- add multi-agent collaboration scaffolding (issue forms, label taxonomy, PR contract)
- add governance workflows for issue label defaults, issue-link enforcement, and project intake sync
- add reusable ops scripts and workflow doc for label sync and branch-protection baseline

## Test plan
- [x] `npm run typecheck`
- [x] `bash -n scripts/workflow/sync-github-labels.sh scripts/workflow/apply-branch-protection-baseline.sh`
- [x] live API apply + verification for labels and baseline branch protection on `ingpoc/nanoclaw`
- [ ] post-merge live event tests (issue intake + project auto-add + PR issue-link enforcement)

## Notes
`npm run format:check` currently fails on existing repository baseline files under `src/**` unrelated to this PR.

🤖 Generated with Codex