### PR TITLE
fix: make project intake sync robust without secret at job-if

### DIFF
--- a/.github/workflows/project-intake-sync.yml
+++ b/.github/workflows/project-intake-sync.yml
@@ -12,11 +12,17 @@ permissions:
 
 jobs:
   add-to-project:
-    if: secrets.ADD_TO_PROJECT_PAT != ''
     runs-on: ubuntu-latest
+    env:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
     steps:
+      - name: Skip when project token is unavailable
+        if: ${{ env.ADD_TO_PROJECT_PAT == '' }}
+        run: echo "ADD_TO_PROJECT_PAT is not configured; skipping."
+
       - name: Add item to project
+        if: ${{ env.ADD_TO_PROJECT_PAT != '' }}
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/users/ingpoc/projects/1
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ env.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary
- remove invalid job-level secret condition in project intake workflow
- add step-level guard for missing ADD_TO_PROJECT_PAT
- keep add-to-project step gated behind env token

## Test plan
- create issue and verify workflow run succeeds
- verify issue is added to GitHub project
