### PR TITLE
Fix/runtime observability and IPC diagnostics

### DIFF
--- a/scripts/jarvis-preflight.sh
+++ b/scripts/jarvis-preflight.sh
@@ -324,7 +324,7 @@ if [ -f "$DB_PATH" ] && have_cmd sqlite3; then
       echo "[INFO] stale runtime owner: ${runtime_owner_name:-host}|${runtime_owner_mode:-unknown}|${runtime_owner_pid:-unknown}|${runtime_owner_heartbeat:-unknown}|${runtime_owner_claimed_by:-unknown}"
     fi
   else
-    fail "db.runtime_owners.active" "runtime owner row missing"
+    pass "db.runtime_owners.active" "runtime owner row not recorded; launchd service health is authoritative"
   fi
 
   if sqlite3 "$DB_PATH" ".schema worker_runs" | grep -q "CREATE TABLE"; then
@@ -341,8 +341,9 @@ if [ -f "$DB_PATH" ] && have_cmd sqlite3; then
     selected_session_id
     effective_session_id
     session_resume_status
-    run_generation
-    stop_reason
+    last_progress_summary
+    last_progress_at
+    steer_count
   )
   missing_cols=()
   for col in "${required_cols[@]}"; do

--- a/scripts/jarvis-recover.sh
+++ b/scripts/jarvis-recover.sh
@@ -63,35 +63,35 @@ step() {
 
 wait_for_nanoclaw_ready() {
   local restart_started_at="$1"
-
-  if ! command -v sqlite3 >/dev/null 2>&1; then
-    echo "[WARN] sqlite3 not available; skipping runtime readiness wait"
-    return 0
-  fi
-
-  if [ ! -f "$DB_PATH" ]; then
-    echo "[WARN] sqlite DB missing; skipping runtime readiness wait ($DB_PATH)"
-    return 0
-  fi
+  local launchd_label="gui/$(id -u)/com.nanoclaw"
+  local log_file="$ROOT_DIR/logs/nanoclaw.log"
 
   local deadline=$((SECONDS + RUNTIME_READY_TIMEOUT_SEC))
   while [ "$SECONDS" -lt "$deadline" ]; do
-    local owner_row
-    owner_row="$(sqlite3 -separator '|' "$DB_PATH" \
-      "SELECT pid, heartbeat_at FROM runtime_owners WHERE owner_name = 'host' AND heartbeat_at >= '$restart_started_at' LIMIT 1;" \
-      2>/dev/null || true)"
-    local loop_ready_at
-    loop_ready_at="$(sqlite3 "$DB_PATH" \
-      "SELECT value FROM router_state WHERE key = 'host_message_loop_ready_at' AND value >= '$restart_started_at' LIMIT 1;" \
-      2>/dev/null || true)"
-    if [ -n "$owner_row" ]; then
-      local runtime_pid runtime_heartbeat
-      IFS='|' read -r runtime_pid runtime_heartbeat <<<"$owner_row"
-      if [[ "$runtime_pid" =~ ^[0-9]+$ ]] && kill -0 "$runtime_pid" 2>/dev/null && [ -n "$loop_ready_at" ]; then
-        echo "[PASS] runtime ready (pid=$runtime_pid heartbeat=$runtime_heartbeat loop_ready=$loop_ready_at)"
+    local runtime_pid=""
+    if command -v launchctl >/dev/null 2>&1; then
+      runtime_pid="$(launchctl print "$launchd_label" 2>/dev/null | awk -F'= ' '/pid = /{print $2; exit}' | tr -d ';')"
+    fi
+
+    local loop_ready_at=""
+    if command -v sqlite3 >/dev/null 2>&1 && [ -f "$DB_PATH" ]; then
+      loop_ready_at="$(sqlite3 "$DB_PATH" \
+        "SELECT value FROM router_state WHERE key = 'host_message_loop_ready_at' AND value >= '$restart_started_at' LIMIT 1;" \
+        2>/dev/null || true)"
+    fi
+
+    if [[ "$runtime_pid" =~ ^[0-9]+$ ]] && kill -0 "$runtime_pid" 2>/dev/null; then
+      if [ -n "$loop_ready_at" ]; then
+        echo "[PASS] runtime ready (pid=$runtime_pid loop_ready=$loop_ready_at)"
+        return 0
+      fi
+
+      if [ -f "$log_file" ] && tail -n 200 "$log_file" | grep -F "($runtime_pid)" | grep -Eq 'Connected to WhatsApp|NanoClaw running|IPC watcher started'; then
+        echo "[PASS] runtime ready (pid=$runtime_pid log_ready=true)"
         return 0
       fi
     fi
+
     sleep 1
   done
 

--- a/scripts/jarvis-reliability.sh
+++ b/scripts/jarvis-reliability.sh
@@ -206,7 +206,7 @@ if [ -f "$DB_PATH" ] && have_cmd sqlite3; then
         info "runtime owner claimed_by: $runtime_owner_claimed_by"
       fi
     else
-      fail "runtime owner row missing"
+      pass "runtime owner row not recorded; launchd service health is authoritative"
     fi
   else
     fail "runtime_owners table missing"
@@ -223,8 +223,6 @@ if [ -f "$DB_PATH" ] && have_cmd sqlite3; then
     last_progress_summary
     last_progress_at
     steer_count
-    run_generation
-    stop_reason
   )
   missing_cols=()
   for col in "${required_cols[@]}"; do

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -224,6 +224,13 @@ function buildVolumeMounts(
   if (fs.existsSync(skillsSrc)) {
     for (const skillDir of fs.readdirSync(skillsSrc)) {
       const srcDir = path.join(skillsSrc, skillDir);
+      if (!fs.existsSync(srcDir)) {
+        logger.debug(
+          { skillDir, srcDir },
+          'Skipping staged skill entry with missing target',
+        );
+        continue;
+      }
       let srcStat: fs.Stats;
       try {
         srcStat = fs.statSync(srcDir);

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -99,6 +99,25 @@ describe('schedule_task authorization', () => {
     expect(allTasks[0].group_folder).toBe('other-group');
   });
 
+  it('normalizes legacy task payloads for self-scheduled runs', async () => {
+    await processTaskIpc(
+      {
+        type: 'task',
+        prompt: 'legacy self task',
+        schedule_type: 'once',
+        schedule_value: '2025-06-01T00:00:00',
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    const allTasks = getAllTasks();
+    expect(allTasks.length).toBe(1);
+    expect(allTasks[0].group_folder).toBe('other-group');
+    expect(allTasks[0].chat_jid).toBe('other@g.us');
+  });
+
   it('non-main group can schedule for itself', async () => {
     await processTaskIpc(
       {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -166,6 +166,70 @@ export function startIpcWatcher(deps: IpcDeps): void {
   logger.info('IPC watcher started (per-group namespaces)');
 }
 
+function findGroupJidByFolder(
+  registeredGroups: Record<string, RegisteredGroup>,
+  folder: string,
+): string | undefined {
+  for (const [jid, group] of Object.entries(registeredGroups)) {
+    if (group.folder === folder) return jid;
+  }
+
+  return undefined;
+}
+
+function normalizeTaskIpcPayload(
+  data: {
+    type: string;
+    taskId?: string;
+    prompt?: string;
+    schedule_type?: string;
+    schedule_value?: string;
+    context_mode?: string;
+    script?: string;
+    groupFolder?: string;
+    chatJid?: string;
+    targetJid?: string;
+    jid?: string;
+    name?: string;
+    folder?: string;
+    trigger?: string;
+    requiresTrigger?: boolean;
+    containerConfig?: RegisteredGroup['containerConfig'];
+  },
+  sourceGroup: string,
+  isMain: boolean,
+  registeredGroups: Record<string, RegisteredGroup>,
+): typeof data {
+  if (data.type !== 'task') return data;
+
+  const targetJid =
+    data.targetJid ||
+    data.chatJid ||
+    (data.groupFolder
+      ? findGroupJidByFolder(registeredGroups, data.groupFolder)
+      : undefined) ||
+    (!isMain ? findGroupJidByFolder(registeredGroups, sourceGroup) : undefined);
+
+  if (
+    data.prompt &&
+    data.schedule_type &&
+    data.schedule_value &&
+    targetJid
+  ) {
+    logger.info(
+      { sourceGroup, targetJid },
+      'Normalizing legacy IPC task payload to schedule_task',
+    );
+    return {
+      ...data,
+      type: 'schedule_task',
+      targetJid,
+    };
+  }
+
+  return data;
+}
+
 export async function processTaskIpc(
   data: {
     type: string;
@@ -191,6 +255,7 @@ export async function processTaskIpc(
   deps: IpcDeps,
 ): Promise<void> {
   const registeredGroups = deps.registeredGroups();
+  data = normalizeTaskIpcPayload(data, sourceGroup, isMain, registeredGroups);
 
   switch (data.type) {
     case 'schedule_task':
@@ -475,6 +540,6 @@ export async function processTaskIpc(
       break;
 
     default:
-      logger.warn({ type: data.type }, 'Unknown IPC task type');
+      logger.warn({ sourceGroup, type: data.type }, 'Unknown IPC task type');
   }
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -210,12 +210,7 @@ function normalizeTaskIpcPayload(
       : undefined) ||
     (!isMain ? findGroupJidByFolder(registeredGroups, sourceGroup) : undefined);
 
-  if (
-    data.prompt &&
-    data.schedule_type &&
-    data.schedule_value &&
-    targetJid
-  ) {
+  if (data.prompt && data.schedule_type && data.schedule_value && targetJid) {
     logger.info(
       { sourceGroup, targetJid },
       'Normalizing legacy IPC task payload to schedule_task',


### PR DESCRIPTION
## Linked Work Item

- No issue: maintenance

## Type of Change

- [ ] **Skill** - adds or updates skill content in `.claude/skills/`
- [ ] **Feature** - new product behavior
- [x] **Fix** - bug fix or security fix to source code
- [x] **Reliability** - runtime or operational hardening
- [ ] **Governance/Workflow** - CI/policy/process automation changes
- [ ] **Docs** - documentation-only change

## Summary

Hardens NanoClaw runtime observability around the post-recovery state.

Scope:
- normalize legacy IPC task payloads with `type: "task"` into `schedule_task` when the payload is clearly a scheduled task request
- stop spamming runtime logs for broken optional `container/skills/*` symlink targets
- align `jarvis-preflight`, `jarvis-reliability`, and `jarvis-recover` with the current runtime schema and readiness signals so they stop reporting false failures

Expected outcome:
- fewer misleading runtime warnings
- no false red health checks from removed legacy DB fields
- recovery/readiness checks track the signals the current runtime actually emits

## Verification Evidence

- [x] Build/type/test checks executed (or intentionally not required)
- [x] Risk-prone paths were validated
- [ ] Relevant acceptance criteria from linked issue are satisfied
- [ ] Required evidence from the linked issue is included
- [ ] Platform pilot handoff is ready for Codex review when applicable

Verification run:
- `npm run typecheck`
- `bash -n scripts/jarvis-preflight.sh scripts/jarvis-recover.sh scripts/jarvis-reliability.sh`
- targeted tests for IPC/container-runner passed in the original repo checkout before branch extraction

Caveat:
- DB-backed `ipc-auth` tests in the clean PR clone were blocked by a local `better-sqlite3` native binding mismatch under the clone's Node runtime, so the meaningful pass signal there is `typecheck` plus the previously-run targeted tests in the active repo checkout.

## Risks and Rollback

Risks:
- legacy `type: "task"` payload normalization could classify an unexpected task payload as a schedule request if it includes the schedule fields and a resolvable target
- diagnostics now treat missing runtime-owner rows as non-fatal, so future ownership regressions must still be caught by launchd/log readiness signals

Rollback:
- revert this PR to restore the prior strict diagnostics and IPC behavior
