### PR TITLE
Fix/container OneCLI bootstrap composition

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -60,7 +60,9 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Container input (prompt, group info) is passed via stdin JSON.
 # Credentials are injected by the host's credential proxy — never passed here.
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+COPY container/onecli-secrets-manifest.sh /app/onecli-secrets-manifest.sh
+RUN chmod +x /app/onecli-secrets-manifest.sh
+RUN printf '#!/bin/bash\nset -e\n. /app/onecli-secrets-manifest.sh\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -60,9 +60,15 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Container input (prompt, group info) is passed via stdin JSON.
 # Credentials are injected by the host's credential proxy — never passed here.
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
+#
+# Shared bootstrap-env.sh sources all present OneCLI startup hooks so OneCLI SSL
+# trust and placeholder-secret bootstrap compose safely regardless of PR merge
+# order.
+COPY container/bootstrap-env.sh /app/bootstrap-env.sh
+COPY container/bootstrap-ssl.sh /app/bootstrap-ssl.sh
 COPY container/onecli-secrets-manifest.sh /app/onecli-secrets-manifest.sh
-RUN chmod +x /app/onecli-secrets-manifest.sh
-RUN printf '#!/bin/bash\nset -e\n. /app/onecli-secrets-manifest.sh\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+RUN chmod +x /app/bootstrap-env.sh /app/bootstrap-ssl.sh /app/onecli-secrets-manifest.sh
+RUN printf '#!/bin/bash\nset -e\n. /app/bootstrap-env.sh\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node

--- a/container/bootstrap-env.sh
+++ b/container/bootstrap-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# bootstrap-env.sh — compose optional OneCLI startup hooks
+#
+# Source every known bootstrap helper if it is present in this image. This keeps
+# branch-specific runtime fixes stack-safe when multiple PRs touch container
+# startup in parallel and land in either order.
+
+for hook in /app/bootstrap-ssl.sh /app/onecli-secrets-manifest.sh; do
+  if [ -f "$hook" ]; then
+    # shellcheck disable=SC1090
+    . "$hook"
+  fi
+done

--- a/container/bootstrap-ssl.sh
+++ b/container/bootstrap-ssl.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# bootstrap-ssl.sh — OneCLI CA cert auto-configuration
+#
+# Detects the OneCLI combined CA bundle at the well-known mount path and
+# exports SSL env vars so that git, Node.js, npm, and curl all trust the
+# OneCLI HTTPS intercept proxy.  Must be sourced (`. /app/bootstrap-ssl.sh`)
+# before any network operation.
+#
+# Architecture: credentials are never stored here.  The CA cert only enables
+# TLS trust for the proxy; the proxy injects real secrets at intercept time.
+
+ONECLI_CA="/tmp/nanoclaw-onecli/onecli-combined-ca.pem"
+
+if [ -f "$ONECLI_CA" ]; then
+  export GIT_SSL_CAINFO="$ONECLI_CA"
+  export NODE_EXTRA_CA_CERTS="$ONECLI_CA"
+  export SSL_CERT_FILE="$ONECLI_CA"
+  echo "[bootstrap-ssl] OneCLI CA detected — SSL env vars configured." >&2
+else
+  echo "[bootstrap-ssl] OneCLI CA not present at $ONECLI_CA — using system defaults." >&2
+fi

--- a/container/onecli-secrets-manifest.sh
+++ b/container/onecli-secrets-manifest.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# onecli-secrets-manifest.sh — OneCLI placeholder bootstrap
+#
+# For each secret name that the OneCLI Agent Vault maps, export VAR=placeholder
+# if the variable is not already set. The OneCLI HTTPS intercept proxy replaces
+# "placeholder" with the real credential value at request time — never stored here.
+#
+# Skill pre-flight checks (e.g. `[ -z "$COLOSSEUM_COPILOT_PAT" ]`) pass because
+# the variable is non-empty.  The proxy then injects the real token on the wire.
+#
+# To add a new secret: append the name to ONECLI_SECRETS below, document it in
+# docs/credentials.md, and add the mapping in the OneCLI vault config.
+#
+# Architecture: raw credentials are NEVER stored in this file or any container image.
+
+ONECLI_SECRETS=(
+  COLOSSEUM_COPILOT_PAT
+  GITHUB_TOKEN
+  GH_TOKEN
+  ANTHROPIC_API_KEY
+  AGENTMAIL_API_KEY
+  OPENAI_API_KEY
+  LINEAR_API_KEY
+  NOTION_API_KEY
+  SLACK_BOT_TOKEN
+  TELEGRAM_BOT_TOKEN
+  DISCORD_BOT_TOKEN
+)
+
+for secret in "${ONECLI_SECRETS[@]}"; do
+  if [ -z "${!secret:-}" ]; then
+    export "${secret}=placeholder"
+    echo "[onecli-secrets] ${secret} not set — exported as placeholder (proxy will inject real value)" >&2
+  fi
+done

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,13 @@ Owner for:
 Should not contain:
 - policy, workflow detail, or implementation behavior that belongs in a more specific owner doc, skill, or enforcement surface
 
+## [Unreleased]
+
+### Bug Fixes
+
+- fix(container): bootstrap OneCLI placeholder env vars at container startup
+  - Motivation: Skills pre-flight checks (`[ -z "$COLOSSEUM_COPILOT_PAT" ]`) failed because secret vars were unset, even though OneCLI proxy injects real values at HTTPS intercept time. The new `onecli-secrets-manifest.sh` exports `VAR=placeholder` for each known secret at startup so checks pass. See `docs/credentials.md` for the full placeholder pattern.
+
 ## 2026-03-04
 
 - Synced from: `upstream/main` into `andy-autonomous`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,8 +15,12 @@ Should not contain:
 
 ### Bug Fixes
 
+- fix(container): auto-configure OneCLI CA cert SSL env vars at container startup
+  - Motivation: `npx skills add` and other npm/git/curl calls failed with SSL cert errors because the OneCLI CA bundle at `/tmp/nanoclaw-onecli/onecli-combined-ca.pem` was not picked up automatically. The new `bootstrap-ssl.sh` configures `GIT_SSL_CAINFO`, `NODE_EXTRA_CA_CERTS`, and `SSL_CERT_FILE` before network operations run.
 - fix(container): bootstrap OneCLI placeholder env vars at container startup
   - Motivation: Skills pre-flight checks (`[ -z "$COLOSSEUM_COPILOT_PAT" ]`) failed because secret vars were unset, even though OneCLI proxy injects real values at HTTPS intercept time. The new `onecli-secrets-manifest.sh` exports `VAR=placeholder` for each known secret at startup so checks pass. See `docs/credentials.md` for the full placeholder pattern.
+- fix(container): compose OneCLI startup hooks through a shared bootstrap loader
+  - Motivation: The placeholder bootstrap and SSL bootstrap both patch container startup. Loading hooks through `bootstrap-env.sh` keeps the fixes merge-order safe so landing one PR does not drop the other startup behavior.
 
 ## 2026-03-04
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,48 @@
+# Credentials — OneCLI Placeholder Pattern
+
+All secrets in NanoClaw agent containers are provided by the **OneCLI Agent Vault** via HTTPS proxy interception. Raw credentials are **never** stored in container images, environment files, or source code.
+
+## How It Works
+
+1. `container/onecli-secrets-manifest.sh` is sourced at container startup (via `entrypoint.sh`).
+2. For each secret name in the manifest, if the variable is not already set, it exports `VAR=placeholder`.
+3. The OneCLI HTTPS intercept proxy detects outgoing requests and replaces the `placeholder` value with the real credential in the `Authorization` header (or equivalent) at the wire level.
+4. Skills, tools, and SDKs never see or store the real credential — only the proxy does.
+
+## Why Placeholder?
+
+Skill pre-flight checks often guard against missing credentials:
+
+```bash
+[ -z "$COLOSSEUM_COPILOT_PAT" ] && echo "Missing PAT" && exit 1
+```
+
+Without the placeholder bootstrap, these checks would fail even though the proxy would successfully inject the real token at request time. Setting `VAR=placeholder` satisfies the non-empty check while the proxy handles the real injection.
+
+## Known Secret Names (Manifest)
+
+| Variable | Purpose |
+|----------|---------|
+| `COLOSSEUM_COPILOT_PAT` | Colosseum Copilot GitHub PAT for skills engine |
+| `GITHUB_TOKEN` | GitHub API access for worker lanes |
+| `GH_TOKEN` | GitHub CLI authentication |
+| `ANTHROPIC_API_KEY` | Claude API access |
+| `AGENTMAIL_API_KEY` | AgentMail inbox API for OTP flows |
+| `OPENAI_API_KEY` | OpenAI API (fallback LLM) |
+| `LINEAR_API_KEY` | Linear project management |
+| `NOTION_API_KEY` | Notion agent memory |
+| `SLACK_BOT_TOKEN` | Slack channel integration |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot integration |
+| `DISCORD_BOT_TOKEN` | Discord bot integration |
+
+## Adding a New Secret
+
+1. Add the variable name to `ONECLI_SECRETS` in `container/onecli-secrets-manifest.sh`.
+2. Add a row to the table above with purpose.
+3. Add the corresponding mapping in the OneCLI vault configuration (outside this repo — contact the platform team).
+4. Never put real credentials in any file committed to this repository.
+
+## Security Invariant
+
+> **The `placeholder` string must never reach a real API endpoint without the proxy intercepting.**
+> If the proxy is not active, requests will fail authentication — this is the correct safe failure mode.


### PR DESCRIPTION
## Linked Work Item

- No issue: maintenance

## Type of Change

- [ ] **Skill** - adds or updates skill content in `.claude/skills/`
- [x] **Feature** - new product behavior
- [x] **Fix** - bug fix or security fix to source code
- [x] **Reliability** - runtime or operational hardening
- [ ] **Governance/Workflow** - CI/policy/process automation changes
- [x] **Docs** - documentation-only change

## Summary

Combines the two OneCLI container startup fixes into one merge-safe branch.

Scope:
- keep OneCLI CA trust bootstrap (`bootstrap-ssl.sh`)
- keep placeholder secret bootstrap (`onecli-secrets-manifest.sh`)
- introduce shared `bootstrap-env.sh` so both hooks run regardless of PR merge order
- document the combined startup behavior in `docs/CHANGELOG.md`

Expected outcome:
- container startup consistently configures SSL trust for the OneCLI CA bundle
- placeholder env vars unblock pre-flight checks that only test for non-empty values
- landing one startup fix cannot silently drop the other

## Verification Evidence

- [x] Build/type/test checks executed (or intentionally not required)
- [x] Risk-prone paths were validated
- [ ] Relevant acceptance criteria from linked issue are satisfied
- [ ] Required evidence from the linked issue is included
- [ ] Platform pilot handoff is ready for Codex review when applicable

Verification run:
- `bash -n container/bootstrap-env.sh container/bootstrap-ssl.sh container/onecli-secrets-manifest.sh`
- `git diff --check`

Caveat:
- I did not run a full end-to-end NanoClaw container runtime validation for this branch because the current session is quota-limited on the live lane.

## Risks and Rollback

Risks:
- placeholder bootstrap still depends on a maintained allowlist of OneCLI-mapped secret names
- end-to-end behavior still depends on the CA bundle mount and proxy intercept being present in the runtime environment

Rollback:
- revert this PR to restore the prior entrypoint behavior
